### PR TITLE
Refactoring: getGlobals middlewares

### DIFF
--- a/src/CommandBus.php
+++ b/src/CommandBus.php
@@ -30,7 +30,7 @@ class CommandBus implements CommandBusInterface
             throw new UnknowCommandException($command);
         }
 
-        $commandMiddlewares = $this->middlewareResolver->getGlobals();
+        $commandMiddlewares = $this->middlewareResolver->get($command);
 
         $middlewareDispatcher = new CommandMiddlewareDispatcher($commandHandler);
 

--- a/src/CommandMiddlewareResolverInterface.php
+++ b/src/CommandMiddlewareResolverInterface.php
@@ -9,5 +9,5 @@ interface CommandMiddlewareResolverInterface
     /**
      * @return CommandMiddlewareInterface[]
      */
-    public function getGlobals(): array;
+    public function get(CommandInterface $command): array;
 }

--- a/src/QueryBus.php
+++ b/src/QueryBus.php
@@ -30,7 +30,7 @@ class QueryBus implements QueryBusInterface
             throw new UnknowQueryException($query);
         }
 
-        $queryMiddlewares = $this->middlewareResolver->getGlobals();
+        $queryMiddlewares = $this->middlewareResolver->get($query);
 
         $middlewareDispatcher = new QueryMiddlewareDispatcher($queryHandler);
 

--- a/src/QueryMiddlewareResolverInterface.php
+++ b/src/QueryMiddlewareResolverInterface.php
@@ -9,5 +9,5 @@ interface QueryMiddlewareResolverInterface
     /**
      * @return QueryMiddlewareInterface[]
      */
-    public function getGlobals(): array;
+    public function get(QueryInterface $query): array;
 }

--- a/tests/CommandBusTest.php
+++ b/tests/CommandBusTest.php
@@ -88,12 +88,13 @@ final class CommandBusTest extends TestCase
 
         $this->commandMiddlewareResolver = $this
             ->getMockBuilder(CommandMiddlewareResolverInterface::class)
-            ->setMethods((['getGlobals']))
+            ->setMethods((['get']))
             ->getMock()
         ;
 
         $this->commandMiddlewareResolver
-            ->method('getGlobals')
+            ->method('get')
+            ->with($this->command)
             ->will($this->returnCallback(
                 function () {
                     return $this->commandMiddlewareResolverReturn;

--- a/tests/QueryBusTest.php
+++ b/tests/QueryBusTest.php
@@ -120,12 +120,13 @@ final class QueryBusTest extends TestCase
 
         $this->queryMiddlewareResolver = $this
             ->getMockBuilder(QueryMiddlewareResolverInterface::class)
-            ->setMethods((['getGlobals']))
+            ->setMethods((['get']))
             ->getMock()
         ;
 
         $this->queryMiddlewareResolver
-            ->method('getGlobals')
+            ->method('get')
+            ->with($this->query)
             ->will($this->returnCallback(
                 function () {
                     return $this->queryMiddlewareResolverReturn;


### PR DESCRIPTION
This PR change the **getGlobals** method to a **get** one.

This is not the library responsability to decide the order of the middlewares execution during the dispatch. This step will be handle by the resolver during the registration of differents middlewares.

In consequences, the middleware resolver now define a **get** method which accept a query/command in order to retreive the middlewares sequence.